### PR TITLE
autohop: adds disable hop at grand exchange functionality.

### DIFF
--- a/chinautohop/chinautohop.gradle.kts
+++ b/chinautohop/chinautohop.gradle.kts
@@ -23,10 +23,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.18"
+version = "0.0.19"
 
 project.extra["PluginName"] = "Chin auto hop"
-project.extra["PluginDescription"] = "Automatically hops away from people in the wilderness"
+project.extra["PluginDescription"] = "Automatically hops away from people"
 
 dependencies {
     annotationProcessor(group = "org.projectlombok", name = "lombok", version = "1.18.12")

--- a/chinautohop/src/main/java/com/owain/autohop/AutoHopConfig.java
+++ b/chinautohop/src/main/java/com/owain/autohop/AutoHopConfig.java
@@ -46,11 +46,23 @@ public interface AutoHopConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "disableGrandExchange",
+		name = "Disable at Grand Exchange",
+		description = "Don't hop if your player is at the grand exchange",
+		titleSection = "hopTitle",
+		position = 2
+	)
+	default boolean disableGrandExchange()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "cmbBracket",
 		name = "Within combat bracket",
 		description = "Only hop if the player is within your combat bracket",
 		titleSection = "hopTitle",
-		position = 2
+		position = 3
 	)
 	default boolean cmbBracket()
 	{
@@ -62,7 +74,7 @@ public interface AutoHopConfig extends Config
 		name = "Hop on player spawn",
 		description = "Hop when a player  spawns",
 		titleSection = "hopTitle",
-		position = 3
+		position = 4
 	)
 	default boolean alwaysHop()
 	{
@@ -74,7 +86,7 @@ public interface AutoHopConfig extends Config
 		name = "Hop on chat message",
 		description = "Hop whenever any message is entered into chat",
 		titleSection = "hopTitle",
-		position = 4
+		position = 5
 	)
 	default boolean chatHop()
 	{
@@ -86,7 +98,7 @@ public interface AutoHopConfig extends Config
 		name = "Hop radius",
 		description = "Hop only when another player enters radius",
 		titleSection = "hopTitle",
-		position = 5
+		position = 6
 	)
 	default boolean hopRadius()
 	{
@@ -98,7 +110,7 @@ public interface AutoHopConfig extends Config
 		name = "Player radius",
 		description = "Radius (tiles) for player to be within to trigger hop",
 		titleSection = "hopTitle",
-		position = 6,
+		position = 7,
 		hidden = true,
 		unhide = "hopRadius"
 	)
@@ -112,7 +124,7 @@ public interface AutoHopConfig extends Config
 		name = "Skulled",
 		description = "Hop when a player within your combat bracket spawns that has a skull",
 		titleSection = "hopTitle",
-		position = 7,
+		position = 8,
 		hide = "alwaysHop"
 	)
 	default boolean skulledHop()
@@ -125,7 +137,7 @@ public interface AutoHopConfig extends Config
 		name = "Log under",
 		description = "Hop when a player within your combat bracket spawns underneath you",
 		titleSection = "hopTitle",
-		position = 8,
+		position = 9,
 		hide = "alwaysHop"
 	)
 	default boolean underHop()
@@ -137,7 +149,7 @@ public interface AutoHopConfig extends Config
 		keyName = "worldsTitle",
 		name = "Worlds",
 		description = "",
-		position = 9
+		position = 10
 	)
 	default Title worldsTitle()
 	{
@@ -149,7 +161,7 @@ public interface AutoHopConfig extends Config
 		name = "American",
 		description = "Allow hopping to American worlds",
 		titleSection = "worldsTitle",
-		position = 10
+		position = 11
 	)
 	default boolean american()
 	{
@@ -161,7 +173,7 @@ public interface AutoHopConfig extends Config
 		name = "UK",
 		description = "Allow hopping to UK worlds",
 		titleSection = "worldsTitle",
-		position = 11
+		position = 12
 	)
 	default boolean unitedkingdom()
 	{
@@ -173,7 +185,7 @@ public interface AutoHopConfig extends Config
 		name = "German",
 		description = "Allow hopping to German worlds",
 		titleSection = "worldsTitle",
-		position = 12
+		position = 13
 	)
 	default boolean germany()
 	{
@@ -185,7 +197,7 @@ public interface AutoHopConfig extends Config
 		name = "Australian",
 		description = "Allow hopping to Australian worlds",
 		titleSection = "worldsTitle",
-		position = 13
+		position = 14
 	)
 	default boolean australia()
 	{
@@ -196,7 +208,7 @@ public interface AutoHopConfig extends Config
 		keyName = "ignoresTitle",
 		name = "Ignore",
 		description = "",
-		position = 14
+		position = 15
 	)
 	default Title ignoresTitle()
 	{
@@ -208,7 +220,7 @@ public interface AutoHopConfig extends Config
 		name = "Friends",
 		description = "Don't hop when the player spawned is on your friend list",
 		titleSection = "ignoresTitle",
-		position = 15
+		position = 16
 	)
 	default boolean friends()
 	{
@@ -220,7 +232,7 @@ public interface AutoHopConfig extends Config
 		name = "Clan members",
 		description = "Don't hop when the player spawned is in your clan chat",
 		titleSection = "ignoresTitle",
-		position = 16
+		position = 17
 	)
 	default boolean clanmember()
 	{


### PR DESCRIPTION
Disabled by default, uses regionID to check if at the grand exchange as the region is a near perfect square around the GE.